### PR TITLE
use empty array for empty 'tags' attribute to be schema valid again

### DIFF
--- a/CFP-EVAL.yaml
+++ b/CFP-EVAL.yaml
@@ -8,7 +8,7 @@ description: Evaluation and voting system for the submission.
 short_name: CFP-EVAL
 # --- MUST HAVE END
 contact: John Walker
-tags:
+tags: []
 links:
   homepage: http://wiki.local/cfpvoting
   buildchain: http://ci.local/cfpvoting

--- a/CFP-SUBMISSION-DB.yaml
+++ b/CFP-SUBMISSION-DB.yaml
@@ -8,7 +8,7 @@ description: MySQL of all CfP
 short_name: CFP-SUBMISSION-DB
 # --- MUST HAVE END
 contact: John Walker
-tags:
+tags: []
 links:
   homepage: http://wiki.local/cfpdb
   buildchain: http://ci.local/cfpdb

--- a/CNF-DB.yaml
+++ b/CNF-DB.yaml
@@ -8,7 +8,7 @@ description: MySQL of all conference data
 short_name: CNF-DB
 # --- MUST HAVE END
 contact: Stephan Paul
-tags:
+tags: []
 links:
   homepage: http://wiki.local/confdb
   buildchain: http://ci.local/confdb

--- a/CNF-LGN.yaml
+++ b/CNF-LGN.yaml
@@ -8,7 +8,7 @@ description: The Login for all conference needs.
 short_name: CNF-LGN
 # --- MUST HAVE END
 contact: Stephan Paul
-tags:
+tags: []
 links:
   homepage: http://wiki.local/login
   buildchain: http://ci.local/login

--- a/CNF-PRGRM-DB.yaml
+++ b/CNF-PRGRM-DB.yaml
@@ -8,7 +8,7 @@ description: MySQL of all Program data
 short_name: CNF-PRGRM-DB
 # --- MUST HAVE END
 contact: James Blue
-tags:
+tags: []
 links:
   homepage: http://wiki.local/programdb
   buildchain: http://ci.local/programdb

--- a/CNF-REG.yaml
+++ b/CNF-REG.yaml
@@ -8,7 +8,7 @@ description: Registers a user.
 short_name: CNF-REG
 # --- MUST HAVE END
 contact: Stephan Paul
-tags:
+tags: []
 links:
   homepage: http://wiki.local/reg
   buildchain: http://ci.local/reg

--- a/CNF-USR-DB.yaml
+++ b/CNF-USR-DB.yaml
@@ -8,7 +8,7 @@ description: MySQL of all user data
 short_name: CNF-USR-DB
 # --- MUST HAVE END
 contact: Stephan Paul
-tags:
+tags: []
 links:
   homepage: http://wiki.local/userdb
   buildchain: http://ci.local/userdb

--- a/CNF-USR.yaml
+++ b/CNF-USR.yaml
@@ -8,7 +8,7 @@ description: The central user access.
 short_name: CNF-USR
 # --- MUST HAVE END
 contact: Stephan Paul
-tags:
+tags: []
 links:
   homepage: http://wiki.local/user
   buildchain: http://ci.local/user

--- a/CNF-VTNG-DB.yaml
+++ b/CNF-VTNG-DB.yaml
@@ -8,7 +8,7 @@ description: MySQL of all Submission Voting data
 short_name: CNF-VTNG-DB
 # --- MUST HAVE END
 contact: James Blue
-tags:
+tags: []
 links:
   homepage: http://wiki.local/votingdb
   buildchain: http://ci.local/votingdb

--- a/CONF.yaml
+++ b/CONF.yaml
@@ -8,7 +8,7 @@ description: CRUD a conference.
 short_name: CONF
 # --- MUST HAVE END
 contact: Paula Falk
-tags:
+tags: []
 links:
   homepage: http://wiki.local/conf
   buildchain: http://ci.local/conf

--- a/LCTN.yaml
+++ b/LCTN.yaml
@@ -8,7 +8,7 @@ description: Offers the possibility the find a location matching the given param
 short_name: LCTN
 # --- MUST HAVE END
 contact: Patricia May
-tags:
+tags: []
 links:
   homepage: http://wiki.local/location
   buildchain: http://ci.local/location

--- a/PRGM-GEN.yaml
+++ b/PRGM-GEN.yaml
@@ -8,7 +8,7 @@ description: Generates the complete program from the data of voting and CfP.
 short_name: CNF-USR
 # --- MUST HAVE END
 contact: James Blue
-tags:
+tags: []
 links:
   homepage: http://wiki.local/prggen
   buildchain: http://ci.local/prggen

--- a/cfp-submission.yaml
+++ b/cfp-submission.yaml
@@ -8,7 +8,7 @@ description: Collects all submission by the users.
 short_name: cfp-submission
 # --- MUST HAVE END
 contact: John Walker
-tags:
+tags: []
 links:
   homepage: http://wiki.local/submission
   buildchain: http://ci.local/submission


### PR DESCRIPTION
As the schema specifies the "tags" attribute to be of type "array", the demo data needs to be updated accordingly.

Without the fix the pivio-client generates the error "/tags : instance type (null) does not match any allowed primitive type (allowed: ["array"])" while trying to upload the demo data.